### PR TITLE
add debug server

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/containeroo/heartbeats/internal/config"
+	"github.com/containeroo/heartbeats/internal/debugserver"
 	"github.com/containeroo/heartbeats/internal/flag"
 	"github.com/containeroo/heartbeats/internal/heartbeat"
 	"github.com/containeroo/heartbeats/internal/history"
@@ -78,6 +79,11 @@ func Run(ctx context.Context, webFS fs.FS, version, commit string, args []string
 		history,
 		logger,
 	)
+
+	// Run debug server if enabled
+	if flags.Debug {
+		debugserver.Run(ctx, flags.DebugServerPort, mgr, dispatcher, logger)
+	}
 
 	// Create server and run forever
 	router := server.NewRouter(

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -21,4 +21,5 @@ type EventType int
 const (
 	EventReceive EventType = iota // EventReceive is a heartbeat ping.
 	EventFail                     // EventFail is a manual failure.
+	EventTest                     // EventTest is a test notification.
 )

--- a/internal/debugserver/debugserver.go
+++ b/internal/debugserver/debugserver.go
@@ -1,0 +1,41 @@
+package debugserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/containeroo/heartbeats/internal/handlers"
+	"github.com/containeroo/heartbeats/internal/heartbeat"
+	"github.com/containeroo/heartbeats/internal/notifier"
+)
+
+// Run starts the local-only debug server for manual testing.
+func Run(ctx context.Context, port int, mgr *heartbeat.Manager, dispatcher *notifier.Dispatcher, logger *slog.Logger) {
+	mux := http.NewServeMux()
+
+	mux.Handle("GET /internal/receiver/{id}", handlers.TestReceiverHandler(dispatcher, logger))
+	mux.Handle("GET /internal/heartbeat/{id}", handlers.TestHeartbeatHandler(mgr, logger))
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	logger.Info("starting debug server", "listenAddr", addr)
+
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	// Graceful shutdown on ctx cancel.
+	go func() {
+		<-ctx.Done()
+		_ = server.Close()
+	}()
+
+	// Serve requests on 127.0.0.1 until shutdown.
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("debug server error", "error", err)
+		}
+	}()
+}

--- a/internal/debugserver/debugserver_test.go
+++ b/internal/debugserver/debugserver_test.go
@@ -1,0 +1,60 @@
+package debugserver
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containeroo/heartbeats/internal/heartbeat"
+	"github.com/containeroo/heartbeats/internal/history"
+	"github.com/containeroo/heartbeats/internal/notifier"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugServer_Run(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Setup basic in-memory state
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	hist := history.NewRingStore(5)
+	store := notifier.NewReceiverStore()
+	disp := notifier.NewDispatcher(store, logger, hist, 1, 1*time.Millisecond, 10)
+
+	hbCfg := map[string]heartbeat.HeartbeatConfig{
+		"test-hb": {
+			Description: "demo",
+			Interval:    time.Second,
+			Grace:       time.Second,
+			Receivers:   []string{"r1"},
+		},
+	}
+	mgr := heartbeat.NewManagerFromHeartbeatMap(ctx, hbCfg, disp.Mailbox(), hist, logger)
+
+	// Pick a random free port
+	port := 8089
+	Run(ctx, port, mgr, disp, logger)
+
+	// Wait for server to start
+	time.Sleep(100 * time.Millisecond)
+
+	t.Run("receiver test handler", func(t *testing.T) {
+		url := fmt.Sprintf("http://127.0.0.1:%d/internal/receiver/r1", port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		defer resp.Body.Close() // nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("heartbeat test handler", func(t *testing.T) {
+		url := fmt.Sprintf("http://127.0.0.1:%d/internal/heartbeat/test-hb", port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		defer resp.Body.Close() // nolint:errcheck
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/internal/handlers/test.go
+++ b/internal/handlers/test.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/containeroo/heartbeats/internal/heartbeat"
+	"github.com/containeroo/heartbeats/internal/notifier"
+)
+
+// TestReceiverHandler allows sending a test notification to a specific receiver
+func TestReceiverHandler(dispatcher *notifier.Dispatcher, logger *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		if id == "" {
+			http.Error(w, "missing id", http.StatusBadRequest)
+			return
+		}
+
+		logger.Info("Test request received", "receiver", id)
+
+		dispatcher.Mailbox() <- notifier.NotificationData{
+			ID:        fmt.Sprintf("manual-test-%s", time.Now().Format(time.RFC3339)),
+			Receivers: []string{id},
+			Title:     "Test Notification",
+			Message:   "This is a test notification",
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok") // nolint:errcheck
+	})
+}
+
+// TestHeartbeatHandler allows sending a test notification to a specific heartbeat
+func TestHeartbeatHandler(mgr *heartbeat.Manager, logger *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		if id == "" {
+			http.Error(w, "missing id", http.StatusBadRequest)
+			return
+		}
+
+		logger.Info("Test request heartbeat", "heartbeat", id)
+
+		if err := mgr.HandleTest(id); err != nil {
+			logger.Error("handle test failed", "id", id, "err", err)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok") // nolint:errcheck
+	})
+}

--- a/internal/handlers/test_test.go
+++ b/internal/handlers/test_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containeroo/heartbeats/internal/heartbeat"
+	"github.com/containeroo/heartbeats/internal/history"
+	"github.com/containeroo/heartbeats/internal/notifier"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestReceiverHandler(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	hist := history.NewRingStore(10)
+	store := notifier.InitializeStore(nil, false, "0.0.0", logger)
+	disp := notifier.NewDispatcher(store, logger, hist, 1, 1, 10)
+
+	handler := TestReceiverHandler(disp, logger)
+
+	t.Run("missing id", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "/internal/receiver/", nil)
+		rec := httptest.NewRecorder()
+
+		// simulate missing path value
+		req.SetPathValue("id", "")
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "missing id\n", rec.Body.String())
+	})
+
+	t.Run("sends test notification", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "/internal/receiver/test-rec", nil)
+		rec := httptest.NewRecorder()
+
+		req.SetPathValue("id", "test-rec")
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "ok", rec.Body.String())
+	})
+}
+
+func TestTestHeartbeatHandler(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(&strings.Builder{}, nil))
+	hist := history.NewRingStore(10)
+	store := notifier.InitializeStore(nil, false, "0.0.0", logger)
+	disp := notifier.NewDispatcher(store, logger, hist, 1, 1, 10)
+
+	hbName := "test-hb"
+	cfg := heartbeat.HeartbeatConfigMap{
+		hbName: {
+			ID:          hbName,
+			Description: "test heartbeat",
+			Interval:    time.Second,
+			Grace:       time.Second,
+			Receivers:   []string{"r1"},
+		},
+	}
+	mgr := heartbeat.NewManagerFromHeartbeatMap(context.Background(), cfg, disp.Mailbox(), hist, logger)
+	handler := TestHeartbeatHandler(mgr, logger)
+
+	t.Run("missing id", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "/internal/heartbeat/", nil)
+		rec := httptest.NewRecorder()
+
+		req.SetPathValue("id", "")
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, "missing id\n", rec.Body.String())
+	})
+
+	t.Run("unknown id", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", "/internal/heartbeat/invalid", nil)
+		rec := httptest.NewRecorder()
+
+		req.SetPathValue("id", "invalid")
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.Contains(t, rec.Body.String(), "unknown heartbeat id")
+	})
+
+	t.Run("trigger test heartbeat", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest("GET", fmt.Sprintf("/internal/heartbeat/%s", hbName), nil)
+		rec := httptest.NewRecorder()
+
+		req.SetPathValue("id", hbName)
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "ok", rec.Body.String())
+	})
+}

--- a/internal/heartbeat/manager.go
+++ b/internal/heartbeat/manager.go
@@ -68,3 +68,13 @@ func (m *Manager) HandleFail(id string) error {
 	a.Mailbox() <- common.EventFail
 	return nil
 }
+
+// HandleTest sends only a notification to the Actor.
+func (m *Manager) HandleTest(id string) error {
+	a, ok := m.actors[id]
+	if !ok {
+		return fmt.Errorf("unknown heartbeat id %q", id)
+	}
+	a.Mailbox() <- common.EventTest
+	return nil
+}


### PR DESCRIPTION
* Add a local debug server to test notifications and bumps
* Introduce a new flag `--debug-server-port` for the debug server
* Improve test coverage across core packages