### PR TITLE
fix: restore the heartbeats_heartbeat_received_total counter

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -138,7 +138,7 @@ func Run(ctx context.Context, appFS fs.FS, version, commit string, args []string
 	}
 	manager.StartAll(ctx)
 
-	svc := service.NewService(manager, notifyManager, historyRecorder)
+	svc := service.NewService(manager, notifyManager, historyRecorder, metricsReg)
 	api.SetService(svc)
 
 	reloadConfigFn := reconcile.NewReloadFunc(

--- a/internal/handler/heartbeat.go
+++ b/internal/handler/heartbeat.go
@@ -23,9 +23,6 @@ func (a *API) Heartbeat() http.HandlerFunc {
 			a.respondJSON(w, http.StatusNotFound, errorResponse{Error: err.Error()})
 			return
 		}
-		if a.metrics != nil {
-			a.metrics.IncHeartbeatReceived(heartbeatID)
-		}
 		a.respondJSON(w, http.StatusOK, statusResponse{Status: "ok"})
 	}
 }

--- a/internal/handler/heartbeat.go
+++ b/internal/handler/heartbeat.go
@@ -23,6 +23,9 @@ func (a *API) Heartbeat() http.HandlerFunc {
 			a.respondJSON(w, http.StatusNotFound, errorResponse{Error: err.Error()})
 			return
 		}
+		if a.metrics != nil {
+			a.metrics.IncHeartbeatReceived(heartbeatID)
+		}
 		a.respondJSON(w, http.StatusOK, statusResponse{Status: "ok"})
 	}
 }

--- a/internal/handler/heartbeat_test.go
+++ b/internal/handler/heartbeat_test.go
@@ -1,1 +1,109 @@
 package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containeroo/heartbeats/internal/heartbeat/service"
+	"github.com/containeroo/heartbeats/internal/metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeService struct {
+	updateErr error
+	updated   []string
+}
+
+func (f *fakeService) HeartbeatSummaries() []service.HeartbeatSummary { return nil }
+func (f *fakeService) ReceiverSummaries() []service.ReceiverSummary   { return nil }
+func (f *fakeService) StatusAll() []service.Status                    { return nil }
+func (f *fakeService) StatusByID(id string) (service.Status, error)   { return service.Status{}, nil }
+
+func (f *fakeService) Update(id string, payload string, now time.Time) error {
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.updated = append(f.updated, id)
+	return nil
+}
+
+func newHeartbeatAPI(svc ServiceProvider, metricsReg *metrics.Registry) *API {
+	api := NewAPI(
+		"test",
+		"test",
+		"http://example.com",
+		slog.New(slog.NewTextHandler(&strings.Builder{}, nil)),
+	)
+	api.SetService(svc)
+	api.SetMetrics(metricsReg)
+	return api
+}
+
+func bump(t *testing.T, api *API, id string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/heartbeat/"+id, strings.NewReader("payload"))
+	req.SetPathValue("id", id)
+	rec := httptest.NewRecorder()
+	api.Heartbeat().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHeartbeatHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("accepted bump increments received counter", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &fakeService{}
+		metricsReg := metrics.NewRegistry()
+		api := newHeartbeatAPI(svc, metricsReg)
+
+		rec := bump(t, api, "api")
+		require.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, []string{"api"}, svc.updated)
+
+		metricsRec := httptest.NewRecorder()
+		api.Metrics().ServeHTTP(metricsRec, httptest.NewRequest("GET", "/metrics", nil))
+		assert.Contains(t,
+			metricsRec.Body.String(),
+			`heartbeats_heartbeat_received_total{heartbeat="api"} 1`,
+			"Expected an accepted bump to increment 'heartbeats_heartbeat_received_total'",
+		)
+	})
+
+	t.Run("rejected bump does not increment received counter", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &fakeService{updateErr: errors.New("heartbeat \"api\" not found")}
+		metricsReg := metrics.NewRegistry()
+		api := newHeartbeatAPI(svc, metricsReg)
+
+		rec := bump(t, api, "api")
+		require.Equal(t, http.StatusNotFound, rec.Code)
+
+		metricsRec := httptest.NewRecorder()
+		api.Metrics().ServeHTTP(metricsRec, httptest.NewRequest("GET", "/metrics", nil))
+		assert.NotContains(t,
+			metricsRec.Body.String(),
+			"heartbeats_heartbeat_received_total{",
+			"Expected a rejected bump to leave 'heartbeats_heartbeat_received_total' untouched",
+		)
+	})
+
+	t.Run("missing id is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &fakeService{}
+		api := newHeartbeatAPI(svc, metrics.NewRegistry())
+
+		rec := bump(t, api, "")
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Empty(t, svc.updated)
+	})
+}

--- a/internal/handler/heartbeat_test.go
+++ b/internal/handler/heartbeat_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/containeroo/heartbeats/internal/heartbeat/service"
-	"github.com/containeroo/heartbeats/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +32,7 @@ func (f *fakeService) Update(id string, payload string, now time.Time) error {
 	return nil
 }
 
-func newHeartbeatAPI(svc ServiceProvider, metricsReg *metrics.Registry) *API {
+func newHeartbeatAPI(svc ServiceProvider) *API {
 	api := NewAPI(
 		"test",
 		"test",
@@ -41,7 +40,6 @@ func newHeartbeatAPI(svc ServiceProvider, metricsReg *metrics.Registry) *API {
 		slog.New(slog.NewTextHandler(&strings.Builder{}, nil)),
 	)
 	api.SetService(svc)
-	api.SetMetrics(metricsReg)
 	return api
 }
 
@@ -57,50 +55,32 @@ func bump(t *testing.T, api *API, id string) *httptest.ResponseRecorder {
 func TestHeartbeatHandler(t *testing.T) {
 	t.Parallel()
 
-	t.Run("accepted bump increments received counter", func(t *testing.T) {
+	t.Run("accepted bump reaches the service", func(t *testing.T) {
 		t.Parallel()
 
 		svc := &fakeService{}
-		metricsReg := metrics.NewRegistry()
-		api := newHeartbeatAPI(svc, metricsReg)
+		api := newHeartbeatAPI(svc)
 
 		rec := bump(t, api, "api")
 		require.Equal(t, http.StatusOK, rec.Code)
 		assert.Equal(t, []string{"api"}, svc.updated)
-
-		metricsRec := httptest.NewRecorder()
-		api.Metrics().ServeHTTP(metricsRec, httptest.NewRequest("GET", "/metrics", nil))
-		assert.Contains(t,
-			metricsRec.Body.String(),
-			`heartbeats_heartbeat_received_total{heartbeat="api"} 1`,
-			"Expected an accepted bump to increment 'heartbeats_heartbeat_received_total'",
-		)
 	})
 
-	t.Run("rejected bump does not increment received counter", func(t *testing.T) {
+	t.Run("service error maps to 404", func(t *testing.T) {
 		t.Parallel()
 
 		svc := &fakeService{updateErr: errors.New("heartbeat \"api\" not found")}
-		metricsReg := metrics.NewRegistry()
-		api := newHeartbeatAPI(svc, metricsReg)
+		api := newHeartbeatAPI(svc)
 
 		rec := bump(t, api, "api")
 		require.Equal(t, http.StatusNotFound, rec.Code)
-
-		metricsRec := httptest.NewRecorder()
-		api.Metrics().ServeHTTP(metricsRec, httptest.NewRequest("GET", "/metrics", nil))
-		assert.NotContains(t,
-			metricsRec.Body.String(),
-			"heartbeats_heartbeat_received_total{",
-			"Expected a rejected bump to leave 'heartbeats_heartbeat_received_total' untouched",
-		)
 	})
 
-	t.Run("missing id is rejected", func(t *testing.T) {
+	t.Run("missing id is rejected before the service", func(t *testing.T) {
 		t.Parallel()
 
 		svc := &fakeService{}
-		api := newHeartbeatAPI(svc, metrics.NewRegistry())
+		api := newHeartbeatAPI(svc)
 
 		rec := bump(t, api, "")
 		require.Equal(t, http.StatusBadRequest, rec.Code)

--- a/internal/heartbeat/service/service.go
+++ b/internal/heartbeat/service/service.go
@@ -13,6 +13,7 @@ import (
 
 	htypes "github.com/containeroo/heartbeats/internal/heartbeat/types"
 	"github.com/containeroo/heartbeats/internal/history"
+	"github.com/containeroo/heartbeats/internal/metrics"
 	"github.com/containeroo/heartbeats/internal/runner"
 )
 
@@ -32,6 +33,7 @@ type Service struct {
 	manager   Store
 	receivers ReceiverStore
 	history   history.Recorder
+	metrics   *metrics.Registry
 }
 
 // Status is the public heartbeat state payload.
@@ -69,11 +71,12 @@ type ReceiverSummary struct {
 }
 
 // NewService constructs a Service from a Manager.
-func NewService(manager Store, receivers ReceiverStore, historyStore history.Recorder) *Service {
+func NewService(manager Store, receivers ReceiverStore, historyStore history.Recorder, metricsReg *metrics.Registry) *Service {
 	return &Service{
 		manager:   manager,
 		receivers: receivers,
 		history:   historyStore,
+		metrics:   metricsReg,
 	}
 }
 
@@ -81,14 +84,29 @@ func NewService(manager Store, receivers ReceiverStore, historyStore history.Rec
 func (s *Service) Update(id string, payload string, now time.Time) error {
 	hb, ok := s.manager.Get(id)
 	if !ok {
+		// Unknown ids are deliberately not counted: the id becomes a metric
+		// label, and counting arbitrary request paths would let callers mint
+		// unbounded label cardinality.
 		return fmt.Errorf("heartbeat %q not found", id)
 	}
 	if ok := hb.State.UpdateSeen(now, payload); !ok {
+		// The state (last seen, payload) was still updated; only the runner
+		// wake-up was dropped. The bump was received, so it counts.
 		s.recordHeartbeatReceived(id, now, len(payload), false)
+		s.incHeartbeatReceived(id)
 		return errors.New("heartbeat mailbox full")
 	}
 	s.recordHeartbeatReceived(id, now, len(payload), true)
+	s.incHeartbeatReceived(id)
 	return nil
+}
+
+// incHeartbeatReceived bumps the received counter when metrics are wired.
+func (s *Service) incHeartbeatReceived(id string) {
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.IncHeartbeatReceived(id)
 }
 
 // StatusByID returns the status for a heartbeat.

--- a/internal/heartbeat/service/service_test.go
+++ b/internal/heartbeat/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/containeroo/heartbeats/internal/config"
 	"github.com/containeroo/heartbeats/internal/heartbeat/types"
 	"github.com/containeroo/heartbeats/internal/history"
+	"github.com/containeroo/heartbeats/internal/metrics"
 	"github.com/containeroo/heartbeats/internal/runner"
 )
 
@@ -87,8 +89,16 @@ func newTestService(t *testing.T) (*Service, *fakeStore, *history.Store) {
 	t.Helper()
 	store := newFakeStore()
 	hist := history.NewStore(10)
-	svc := NewService(store, newReceiverStore(), hist)
+	svc := NewService(store, newReceiverStore(), hist, metrics.NewRegistry())
 	return svc, store, hist
+}
+
+// scrapeMetrics renders the service's metrics registry as Prometheus text.
+func scrapeMetrics(t *testing.T, svc *Service) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	svc.metrics.Metrics().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	return rec.Body.String()
 }
 
 func TestServiceUpdate(t *testing.T) {
@@ -106,6 +116,35 @@ func TestServiceUpdate(t *testing.T) {
 	events := hist.List()
 	require.Len(t, events, 2)
 	require.Equal(t, false, events[1].Fields["enqueued"])
+
+	// Both deliveries were received (the mailbox-full one still updated
+	// state), so both count.
+	require.Contains(t, scrapeMetrics(t, svc),
+		`heartbeats_heartbeat_received_total{heartbeat="api"} 2`)
+}
+
+func TestServiceUpdateUnknownID(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _ := newTestService(t)
+
+	err := svc.Update("ghost", "payload", time.Now())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// Unknown ids must not mint counter series (label cardinality guard).
+	require.NotContains(t, scrapeMetrics(t, svc),
+		"heartbeats_heartbeat_received_total{")
+}
+
+func TestServiceUpdateWithoutMetrics(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	svc := NewService(store, newReceiverStore(), history.NewStore(10), nil)
+	store.s["api"] = newHeartbeat(t, "api", time.Second, 2*time.Second, runner.StageLate, time.Now())
+
+	require.NoError(t, svc.Update("api", "payload", time.Now()))
 }
 
 func TestServiceStatus(t *testing.T) {


### PR DESCRIPTION
`heartbeats_heartbeat_received_total` is registered, documented in the README, and covered by registry tests, but nothing increments it anymore: since v0.22.0 no production series ever appears on `/metrics`, no matter how many bumps arrive.

## Regression trace

- v0.21.0 and earlier incremented it in the bump path, right next to the status gauge: [`internal/heartbeat/actor.go` line 150 at `1f2b091` (v0.20.0)](https://github.com/containeroo/heartbeats/blob/1f2b091a211d02625c1eed900a31d42c7eff69f8/internal/heartbeat/actor.go#L150); the same call is still present at the v0.21.0 tag.
- #147 (released as v0.22.0) decomposed the actor into manager/runner/service. The new receive path kept the history recording but the `IncHeartbeatReceived` call fell out; the state gauge survived because it lives in the sender.
- Since then the only callers of `IncHeartbeatReceived` are its own tests. Nothing ever touches a child of the labeled `CounterVec` (no `WithLabelValues` on any code path), so no series exists and the metric silently vanishes from the exposition. Confirmed live on v0.23.0: bumps accepted (`{"status":"ok"}`, `stage_transition` logged) with no `received_total` series ever appearing.

## The fix

The increment lives in `service.Update`, the single place that sees every bump and can tell the three outcomes apart:

- Accepted bump: counted.
- Mailbox-full bump: counted too. `State.UpdateSeen` has already recorded last-seen and payload before the mailbox send is attempted, and history logs the event as received (`enqueued: false`), so the delivery genuinely arrived; only the runner wake-up was dropped.
- Unknown id: not counted, deliberately. The id becomes a metric label, and counting arbitrary request paths would let callers mint unbounded label cardinality.

Plumbing: `NewService` takes the metrics registry (same pattern as `manager.NewManager`), `run.go` passes the existing `metricsReg`, and the increment is nil-guarded so callers without metrics keep working. The HTTP handler is untouched apart from what was already there.

Tests:

- `internal/heartbeat/service`: accepted + mailbox-full render `heartbeats_heartbeat_received_total{heartbeat="api"} 2` on the registry's exposition; an unknown id creates no series; a nil-metrics service doesn't panic.
- `internal/handler` (`heartbeat_test.go` was an empty placeholder): accepted bump reaches the service and returns 200, a service error maps to 404, a missing id is a 400 that never reaches the service.

## Verification

- `gofmt`, `go vet`, and `go test` pass for `./internal/handler`, `./internal/heartbeat/service`, and `./internal/metrics` (frontend built first for the `web/dist` embed).
- A full `go test ./...` currently fails on master in the packages importing `internal/notify`; that's the pre-existing notifykit build break tracked in #242, unrelated to this change. I baseline-checked the identical failures occur without this diff.

One adjacent thing I noticed but didn't touch: the README's metrics list says `heartbeats_heartbeat_last_status` while the code registers `heartbeats_heartbeat_last_state`.

## Checklist

- [x] The PR has a meaningful title (changelog-ready).
- [x] PR contains a single logical change.
- [x] Documentation: the README already documents this metric; the change makes the code match it.
- [ ] Labels: I can't set labels on this repo; `bug` fits.
- [x] Linked related issues/PRs: #147 (where the regression landed), #242 (why full-tree tests can't run on master right now).
