### PR TITLE
ci: run the unit-test gate on PRs to master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
   pull_request:
     branches:
-      - main
+      - master
     paths:
       - "internal/**"
       - "main.go"


### PR DESCRIPTION
The Unit Tests workflow filters `pull_request` to `branches: [main]`, but the repository's default branch is `master`, so the gate has never run on any PR. That's how #228 merged a notifykit bump that doesn't compile (details in #242). One-line fix: point the filter at `master`.

Two things worth knowing before merging:

- This PR itself won't trigger the workflow: the `paths` filter only matches `internal/**`, `main.go`, `go.mod`, and `go.sum`, and this change touches none of them. The first PR that touches Go code after this merges will run the gate.
- Because master currently doesn't compile (#242), that first Go-touching PR will be red until `internal/notify` is adapted to the new notifykit API. That's the gate working as intended, but if you'd rather not have a red window, fixing #242's compile break first and merging this right after avoids it.

The `workflow_call` and `workflow_dispatch` triggers are untouched.

## Checklist

- [x] The PR has a meaningful title (changelog-ready).
- [x] PR contains a single logical change.
- [x] Documentation: nothing to update.
- [ ] Labels: I can't set labels on this repo; `change` (or `bug`) fits.
- [x] Linked related issues/PRs: fixes the CI half of #242.
